### PR TITLE
UPDATE and DELETE support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+language: rust
+rust:
+  - nightly-2018-03-17
+cache: cargo
+script:
+  - cargo check --all --all-targets
+  - cargo test --verbose --all
+services:
+  zookeeper
+addons:
+  apt:
+    packages:
+    - libhwloc-dev
+    - zookeeperd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ regex = "0.2.6"
 
 [dev-dependencies]
 mysql = "12.0.4"
+zookeeper = { git = "https://github.com/bonifaido/rust-zookeeper", rev = "1167cfce5f5088112bd53983614145e5787b4c8f" }
 
 [lib]
 name = "mysoupql"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ slog = "2.0.6"
 slog-term = "2.0.1"
 regex = "0.2.6"
 
-#[bin]
-#name = "mysoupql"
-#path = "src/main.rs"
+[dev-dependencies]
+mysql = "12.0.4"
+
+[lib]
+name = "mysoupql"
+path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+#![feature(box_syntax, box_patterns)]
+
+extern crate distributary;
+extern crate msql_srv;
+extern crate nom_sql;
+extern crate regex;
+
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate slog;
+
+mod soup_backend;
+mod utils;
+
+pub use soup_backend::SoupBackend;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,13 @@ extern crate clap;
 extern crate distributary;
 extern crate msql_srv;
 extern crate nom_sql;
-extern crate regex;
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate slog;
+#[macro_use]
+extern crate lazy_static;
+
+extern crate regex;
 
 mod soup_backend;
 mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ extern crate msql_srv;
 extern crate nom_sql;
 
 #[macro_use]
-extern crate slog;
-#[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate slog;
 
 extern crate regex;
 
@@ -17,7 +17,7 @@ mod soup_backend;
 mod utils;
 
 use msql_srv::MysqlIntermediary;
-use nom_sql::ColumnSpecification;
+use nom_sql::CreateTableStatement;
 use std::collections::HashMap;
 use std::net;
 use std::sync::{Arc, Mutex};
@@ -67,7 +67,7 @@ fn main() {
     info!(log, "listening on port {}", port);
 
     let query_counter = Arc::new(AtomicUsize::new(0));
-    let schemas: Arc<Mutex<HashMap<String, Vec<ColumnSpecification>>>> =
+    let schemas: Arc<Mutex<HashMap<String, CreateTableStatement>>> =
         Arc::new(Mutex::new(HashMap::default()));
     let auto_increments: Arc<Mutex<HashMap<String, u64>>> =
         Arc::new(Mutex::new(HashMap::default()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(box_syntax, box_patterns)]
+
 #[macro_use]
 extern crate clap;
 extern crate distributary;

--- a/src/soup_backend.rs
+++ b/src/soup_backend.rs
@@ -156,10 +156,10 @@ impl SoupBackend {
                 panic!("DELETE only supports WHERE-clauses on primary keys");
             }
             Some(flattened) => {
-                let mut deleted = 0;
+                let count = flattened.len() as u64;
                 for key in flattened {
                     match mutator.delete(vec![key]) {
-                        Ok(_) => deleted += 1,
+                        Ok(_) => {}
                         Err(e) => {
                             error!(self.log, "delete error: {:?}", e);
                             return results.error(
@@ -170,7 +170,7 @@ impl SoupBackend {
                     };
                 }
 
-                results.completed(deleted, 0)
+                results.completed(count, 0)
             }
         }
     }
@@ -400,7 +400,6 @@ impl SoupBackend {
                 panic!("UPDATE only supports WHERE-clauses on primary keys");
             }
             Some(flattened) => {
-                println!("got here {:?}", flattened);
                 let qc = self.query_count
                     .fetch_add(1, sync::atomic::Ordering::SeqCst);
                 let qname = format!("q_{}", qc);

--- a/src/soup_backend.rs
+++ b/src/soup_backend.rs
@@ -397,8 +397,6 @@ impl SoupBackend {
                 let qc = self.query_count
                     .fetch_add(1, sync::atomic::Ordering::SeqCst);
                 let qname = format!("q_{}", qc);
-                // TODO(ekmartin): does this create an extra set of nodes?
-                // if so we should cache the getter
                 let getter = match self.soup
                     .extend_recipe(format!("QUERY {}: {};", qname, select_q))
                 {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -162,7 +162,7 @@ fn delete_multiple() {
 
 #[test]
 fn delete_bogus() {
-    let d = Deployment::new("delete_multiple");
+    let d = Deployment::new("delete_bogus");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, PRIMARY KEY(id))")
@@ -177,7 +177,7 @@ fn delete_bogus() {
 
 #[test]
 fn delete_bogus_valid_and() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("delete_bogus_valid_and");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, PRIMARY KEY(id))")
@@ -207,7 +207,7 @@ fn delete_bogus_valid_and() {
 
 #[test]
 fn delete_bogus_valid_or() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("delete_bogus_valid_or");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, PRIMARY KEY(id))")
@@ -236,8 +236,8 @@ fn delete_bogus_valid_or() {
 }
 
 #[test]
-fn delete_non_key() {
-    let d = Deployment::new("delete_multiple");
+fn delete_other_column() {
+    let d = Deployment::new("delete_other_column");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -245,14 +245,26 @@ fn delete_non_key() {
     sleep();
 
     assert!(
-        conn.query("DELETE FROM Cats WHERE Cats.id = 1 OR Cats.name = \"bob\"")
+        conn.query("DELETE FROM Cats WHERE Cats.id = 1 OR Cats.name = \"Bob\"")
             .is_err()
     );
 }
 
 #[test]
+fn delete_no_keys() {
+    let d = Deployment::new("delete_no_keys");
+    let opts = setup(&d);
+    let mut conn = mysql::Conn::new(opts).unwrap();
+    conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
+        .unwrap();
+    sleep();
+
+    assert!(conn.query("DELETE FROM Cats WHERE 1 = 1").is_err());
+}
+
+#[test]
 fn update_basic() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("update_basic");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -277,7 +289,7 @@ fn update_basic() {
 
 #[test]
 fn update_pkey() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("update_pkey");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -306,7 +318,7 @@ fn update_pkey() {
 
 #[test]
 fn update_separate() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("update_separate");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -337,7 +349,7 @@ fn update_separate() {
 
 #[test]
 fn update_multiple() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("update_multiple");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -370,8 +382,34 @@ fn update_multiple() {
 }
 
 #[test]
+fn update_no_keys() {
+    let d = Deployment::new("update_no_keys");
+    let opts = setup(&d);
+    let mut conn = mysql::Conn::new(opts).unwrap();
+    conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
+        .unwrap();
+    sleep();
+
+    let query = "UPDATE Cats SET Cats.name = \"Rusty\" WHERE 1 = 1";
+    assert!(conn.query(query).is_err());
+}
+
+#[test]
+fn update_other_column() {
+    let d = Deployment::new("update_no_keys");
+    let opts = setup(&d);
+    let mut conn = mysql::Conn::new(opts).unwrap();
+    conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
+        .unwrap();
+    sleep();
+
+    let query = "UPDATE Cats SET Cats.name = \"Rusty\" WHERE Cats.name = \"Bob\"";
+    assert!(conn.query(query).is_err());
+}
+
+#[test]
 fn update_no_changes() {
-    let d = Deployment::new("delete_basic");
+    let d = Deployment::new("update_no_changes");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
@@ -389,7 +427,7 @@ fn update_no_changes() {
 
 #[test]
 fn update_bogus() {
-    let d = Deployment::new("delete_multiple");
+    let d = Deployment::new("update_bogus");
     let opts = setup(&d);
     let mut conn = mysql::Conn::new(opts).unwrap();
     conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -276,6 +276,37 @@ fn update_basic() {
 }
 
 #[test]
+fn update_separate() {
+    let d = Deployment::new("delete_basic");
+    let opts = setup(&d);
+    let mut conn = mysql::Conn::new(opts).unwrap();
+    conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY(id))")
+        .unwrap();
+    sleep();
+
+    conn.query("INSERT INTO Cats (id, name) VALUES (1, \"Bob\")")
+        .unwrap();
+    sleep();
+
+    {
+        let updated = conn.query("UPDATE Cats SET Cats.name = \"Rusty\" WHERE Cats.id = 1")
+            .unwrap();
+        assert_eq!(updated.affected_rows(), 1);
+    }
+
+    {
+        let updated = conn.query("UPDATE Cats SET Cats.name = \"Rusty II\" WHERE Cats.id = 1")
+            .unwrap();
+        assert_eq!(updated.affected_rows(), 1);
+    }
+
+    let name: String = conn.first("SELECT Cats.name FROM Cats WHERE Cats.id = 1")
+        .unwrap()
+        .unwrap();
+    assert_eq!(name, String::from("Rusty II"));
+}
+
+#[test]
 fn update_multiple() {
     let d = Deployment::new("delete_basic");
     let opts = setup(&d);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,110 @@
+extern crate distributary;
+extern crate msql_srv;
+extern crate mysql;
+extern crate nom_sql;
+
+extern crate mysoupql;
+
+use std::collections::HashMap;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::AtomicUsize;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::thread;
+
+use distributary::{ControllerBuilder, ZookeeperAuthority};
+use msql_srv::MysqlIntermediary;
+use nom_sql::ColumnSpecification;
+
+use mysoupql::SoupBackend;
+
+struct TestName {
+    name: String,
+}
+
+impl TestName {
+    fn new(prefix: &str) -> Self {
+        let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let name = format!(
+            "{}.{}.{}",
+            prefix,
+            current_time.as_secs(),
+            current_time.subsec_nanos()
+        );
+
+        Self { name }
+    }
+}
+
+fn sleep() {
+    thread::sleep(Duration::from_millis(200));
+}
+
+fn setup(test: &TestName) -> mysql::Opts {
+    let zk_addr = "127.0.0.1:2181";
+    let logger = distributary::logger_pls();
+    let l = logger.clone();
+    let n = test.name.clone();
+    thread::spawn(move || {
+        let mut authority = ZookeeperAuthority::new(&format!("{}/{}", zk_addr, n));
+        let mut builder = ControllerBuilder::default();
+        authority.log_with(l.clone());
+        builder.log_with(l);
+        builder.build(Arc::new(authority)).wait();
+    });
+
+    let query_counter = Arc::new(AtomicUsize::new(0));
+    let schemas: Arc<Mutex<HashMap<String, Vec<ColumnSpecification>>>> =
+        Arc::new(Mutex::new(HashMap::default()));
+    let auto_increments: Arc<Mutex<HashMap<String, u64>>> =
+        Arc::new(Mutex::new(HashMap::default()));
+    let soup = SoupBackend::new(
+        zk_addr,
+        &test.name,
+        schemas,
+        auto_increments,
+        query_counter,
+        logger,
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let (s, _) = listener.accept().unwrap();
+        MysqlIntermediary::run_on_tcp(soup, s).unwrap();
+    });
+
+    let mut builder = mysql::OptsBuilder::default();
+    builder.tcp_port(addr.port());
+    builder.into()
+}
+
+#[test]
+fn delete_basic() {
+    let test = TestName::new("delete_basic");
+    let opts = setup(&test);
+    let mut conn = mysql::Conn::new(opts).unwrap();
+    conn.query("CREATE TABLE Cats (id int PRIMARY KEY, name VARCHAR(255), PRIMARY KEY (id))")
+        .unwrap();
+
+    sleep();
+    conn.query("INSERT INTO Cats (id, name) VALUES (1, \"Bob\")")
+        .unwrap();
+    sleep();
+
+    let row = conn.query("SELECT Cats.id, Cats.name FROM Cats WHERE Cats.id = 1")
+        .unwrap()
+        .next();
+    assert!(row.is_some());
+
+    {
+        let deleted = conn.query("DELETE FROM Cats WHERE Cats.id = 1").unwrap();
+        assert_eq!(deleted.affected_rows(), 1);
+    }
+
+    let row = conn.query("SELECT Cats.id, Cats.name FROM Cats WHERE Cats.id = 1")
+        .unwrap()
+        .next();
+    assert!(row.is_none());
+}


### PR DESCRIPTION
This adds support for `UPDATE` and `DELETE` of one or more rows with `WHERE`-clauses on primary keys. It handles a decent amount of edge cases, but definitely far from full coverage.

Probably went a bit overboard with the tests - hopefully it'll help in the long run though. I can send a separate PR with some tests for the other functions as well.

~Currently it needs the `PRIMARY KEY` annotation to be on the field type as well, e.g.
`CREATE TABLE T (id int PRIMARY KEY, PRIMARY KEY (id))` and not just `CREATE TABLE T (id int, PRIMARY KEY (id))` but I'll look into fixing that now (`distributary` seems to need the `PRIMARY KEY (id)` constraint, which should probably be fixed too).~