### PR TITLE
Pin distributary version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Malte Schwarzkopf <malte@csail.mit.edu>"]
 clap = "2.24.0"
 msql-srv = "0.5"
 #distributary = { path = "../distributary" }
-distributary = { git = "https://github.com/mit-pdos/distributary.git" }
+distributary = { git = "https://github.com/mit-pdos/distributary.git", rev = "df4bcf411fa5d3e1d5bcc30f11a6ac321f81ffbb" }
 lazy_static = "1.0.0"
 nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "41a2c94c6b3f5947588610c3766d8eaf7e11ab6d" }
 slog = "2.0.6"


### PR DESCRIPTION
When the nom-sql version is upgraded you start getting really weird errors if the distributary version you have cached uses an older nom-sql version (and it won't get upgraded through `cargo build` - think you have to blow out the cache).

Since we're pinning nom-sql anyway I guess we might as well pin distributary too and avoid the issue altogether?